### PR TITLE
Update SEM example dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# data_example_microscopy_sem
-Example dataset containing scanning electron microscopy (SEM) data to illustrate BIDS convention.
+# data_axondeepseg_sem
+AxonDeepSeg scanning electron microscopy (SEM) dataset
+10 rat spinal cord samples with axon and myelin manual segmentation labels.
 
-Microscopy BEP031 version 0.0.2 (2020-09-21T09:21:00)
+Example dataset containing SEM data to illustrate BIDS convention.
+Microscopy BEP031 version 0.0.4 (2021-07-13T15:14:00)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ SEM dataset for AxonDeepSeg (https://axondeepseg.readthedocs.io/)
 
 10 rat spinal cord samples with axon and myelin manual segmentation labels.
 
-Example dataset containing SEM data to illustrate BIDS convention.
+Example dataset containing scanning electron microscopy (SEM) data to illustrate BIDS convention.
 
 BIDS version 1.6.0 - Microscopy BEP031 version 0.0.4 (2021-07-13T15:14:00)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # data_axondeepseg_sem
 AxonDeepSeg scanning electron microscopy (SEM) dataset
+
 10 rat spinal cord samples with axon and myelin manual segmentation labels.
 
 Example dataset containing SEM data to illustrate BIDS convention.
+
 Microscopy BEP031 version 0.0.4 (2021-07-13T15:14:00)

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ AxonDeepSeg scanning electron microscopy (SEM) dataset
 
 Example dataset containing SEM data to illustrate BIDS convention.
 
-Microscopy BEP031 version 0.0.4 (2021-07-13T15:14:00)
+BIDS version 1.6.0 - Microscopy BEP031 version 0.0.4 (2021-07-13T15:14:00)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # data_axondeepseg_sem
-AxonDeepSeg scanning electron microscopy (SEM) dataset
+SEM dataset for AxonDeepSeg (https://axondeepseg.readthedocs.io/)
 
 10 rat spinal cord samples with axon and myelin manual segmentation labels.
 

--- a/dataset_description.json
+++ b/dataset_description.json
@@ -1,5 +1,5 @@
 {
-	"Name": "data_example_microscopy_sem",
-	"BIDSVersion":"1.4.0",
+	"Name": "data_axondeepseg_sem",
+	"BIDSVersion":"1.6.0 - BEP031 v0.0.4",
 	"License": "MIT"
 }

--- a/derivatives/labels/dataset_description.json
+++ b/derivatives/labels/dataset_description.json
@@ -1,0 +1,5 @@
+{
+	"Name": "data_axondeepseg_sem labels",
+	"BIDSVersion": "1.6.0 - BEP031 v0.0.4",
+	"PipelineDescription": {"Name": "Axon and myelin manual segmentation labels"}
+}

--- a/participants.json
+++ b/participants.json
@@ -1,6 +1,8 @@
 {
     "participant_id": {
-        "LongName": "Participant ID",
         "Description": "Unique participant ID"
+    },
+    "species": {
+        "Description": "Binomial species name from the NCBI Taxonomy (https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi)"
     }
 }

--- a/participants.tsv
+++ b/participants.tsv
@@ -1,9 +1,9 @@
-participant_id
-sub-rat1
-sub-rat2
-sub-rat3
-sub-rat4
-sub-rat5
-sub-rat6
-sub-rat7
-sub-rat8
+participant_id	species
+sub-rat1	rattus norvegicus
+sub-rat2	rattus norvegicus
+sub-rat3	rattus norvegicus
+sub-rat4	rattus norvegicus
+sub-rat5	rattus norvegicus
+sub-rat6	rattus norvegicus
+sub-rat7	rattus norvegicus
+sub-rat8	rattus norvegicus

--- a/samples.json
+++ b/samples.json
@@ -1,10 +1,11 @@
 {
     "sample_id": {
-        "LongName": "Sample ID",
-        "Description": "Unique sample ID"
+        "Description": "Sample ID"
     },
     "participant_id": {
-        "LongName": "Participant ID",
         "Description": "Participant ID from whom tissue samples have been acquired"
+    },
+    "sample_type": {
+        "Description": "Type of sample from ENCODE Biosample Type (https://www.encodeproject.org/profiles/biosample_type)"
     }
 }

--- a/samples.tsv
+++ b/samples.tsv
@@ -1,11 +1,11 @@
-sample_id	participant_id
-sample-data1	sub-rat1
-sample-data5	sub-rat2
-sample-data9	sub-rat3
-sample-data10	sub-rat3
-sample-data11	sub-rat3
-sample-data12	sub-rat4
-sample-data14	sub-rat5
-sample-data15	sub-rat6
-sample-Maxo03img60	sub-rat7
-sample-V915	sub-rat8
+sample_id	participant_id	sample_type
+sample-data1	sub-rat1	tissue
+sample-data5	sub-rat2	tissue
+sample-data9	sub-rat3	tissue
+sample-data10	sub-rat3	tissue
+sample-data11	sub-rat3	tissue
+sample-data12	sub-rat4	tissue
+sample-data14	sub-rat5	tissue
+sample-data15	sub-rat6	tissue
+sample-Maxo03img60	sub-rat7	tissue
+sample-V915	sub-rat8	tissue

--- a/sub-rat1/microscopy/sub-rat1_sample-data1_SEM.json
+++ b/sub-rat1/microscopy/sub-rat1_sample-data1_SEM.json
@@ -2,10 +2,7 @@
     "PixelSize": 0.18,
     "FovWidth": 230,
     "FovHeight": 166,
-    "Species": "rat",
     "BodyPart": "CSPINE",
     "SampleFixation": "4% paraformaldehyde, 2% glutaraldehyde",
-    "Channels": 1,
-    "BitDepth": 8,
     "Environment": "exvivo"
 }

--- a/sub-rat1/microscopy/sub-rat1_sample-data1_SEM.json
+++ b/sub-rat1/microscopy/sub-rat1_sample-data1_SEM.json
@@ -1,7 +1,6 @@
 {
     "PixelSize": 0.18,
-    "FovWidth": 230,
-    "FovHeight": 166,
+    "FieldOfView": [230, 166],
     "BodyPart": "CSPINE",
     "SampleFixation": "4% paraformaldehyde, 2% glutaraldehyde",
     "Environment": "exvivo"

--- a/sub-rat1/microscopy/sub-rat1_sample-data1_SEM.json
+++ b/sub-rat1/microscopy/sub-rat1_sample-data1_SEM.json
@@ -1,5 +1,5 @@
 {
-    "PixelSize": 0.18,
+    "PixelSize": [0.18, 0.18],
     "FieldOfView": [230, 166],
     "BodyPart": "CSPINE",
     "SampleFixation": "4% paraformaldehyde, 2% glutaraldehyde",

--- a/sub-rat2/microscopy/sub-rat2_sample-data5_SEM.json
+++ b/sub-rat2/microscopy/sub-rat2_sample-data5_SEM.json
@@ -1,5 +1,5 @@
 {
-    "PixelSize": 0.093,
+    "PixelSize": [0.093, 0.093],
     "FieldOfView": [119, 89],
     "BodyPart": "CSPINE",
     "SampleFixation": "4% paraformaldehyde, 0% glutaraldehyde",

--- a/sub-rat2/microscopy/sub-rat2_sample-data5_SEM.json
+++ b/sub-rat2/microscopy/sub-rat2_sample-data5_SEM.json
@@ -1,7 +1,6 @@
 {
     "PixelSize": 0.093,
-    "FovWidth": 119,
-    "FovHeight": 89,
+    "FieldOfView": [119, 89],
     "BodyPart": "CSPINE",
     "SampleFixation": "4% paraformaldehyde, 0% glutaraldehyde",
     "Environment": "exvivo"

--- a/sub-rat2/microscopy/sub-rat2_sample-data5_SEM.json
+++ b/sub-rat2/microscopy/sub-rat2_sample-data5_SEM.json
@@ -2,10 +2,7 @@
     "PixelSize": 0.093,
     "FovWidth": 119,
     "FovHeight": 89,
-    "Species": "rat",
     "BodyPart": "CSPINE",
     "SampleFixation": "4% paraformaldehyde, 0% glutaraldehyde",
-    "Channels": 1,
-    "BitDepth": 8,
     "Environment": "exvivo"
 }

--- a/sub-rat3/microscopy/sub-rat3_sample-data10_SEM.json
+++ b/sub-rat3/microscopy/sub-rat3_sample-data10_SEM.json
@@ -2,10 +2,7 @@
     "PixelSize": 0.1,
     "FovWidth": 74,
     "FovHeight": 76,
-    "Species": "rat",
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
-    "Channels": 1,
-    "BitDepth": 8,
     "Environment": "exvivo"
 }

--- a/sub-rat3/microscopy/sub-rat3_sample-data10_SEM.json
+++ b/sub-rat3/microscopy/sub-rat3_sample-data10_SEM.json
@@ -1,7 +1,6 @@
 {
     "PixelSize": 0.1,
-    "FovWidth": 74,
-    "FovHeight": 76,
+    "FieldOfView": [74, 76],
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
     "Environment": "exvivo"

--- a/sub-rat3/microscopy/sub-rat3_sample-data10_SEM.json
+++ b/sub-rat3/microscopy/sub-rat3_sample-data10_SEM.json
@@ -1,5 +1,5 @@
 {
-    "PixelSize": 0.1,
+    "PixelSize": [0.1, 0.1],
     "FieldOfView": [74, 76],
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",

--- a/sub-rat3/microscopy/sub-rat3_sample-data11_SEM.json
+++ b/sub-rat3/microscopy/sub-rat3_sample-data11_SEM.json
@@ -1,5 +1,5 @@
 {
-    "PixelSize": 0.1,
+    "PixelSize": [0.1, 0.1],
     "FieldOfView": [77, 84],
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",

--- a/sub-rat3/microscopy/sub-rat3_sample-data11_SEM.json
+++ b/sub-rat3/microscopy/sub-rat3_sample-data11_SEM.json
@@ -1,7 +1,6 @@
 {
     "PixelSize": 0.1,
-    "FovWidth": 77,
-    "FovHeight": 84,
+    "FieldOfView": [77, 84],
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
     "Environment": "exvivo"

--- a/sub-rat3/microscopy/sub-rat3_sample-data11_SEM.json
+++ b/sub-rat3/microscopy/sub-rat3_sample-data11_SEM.json
@@ -2,10 +2,7 @@
     "PixelSize": 0.1,
     "FovWidth": 77,
     "FovHeight": 84,
-    "Species": "rat",
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
-    "Channels": 1,
-    "BitDepth": 8,
     "Environment": "exvivo"
 }

--- a/sub-rat3/microscopy/sub-rat3_sample-data9_SEM.json
+++ b/sub-rat3/microscopy/sub-rat3_sample-data9_SEM.json
@@ -1,7 +1,6 @@
 {
     "PixelSize": 0.1,
-    "FovWidth": 76,
-    "FovHeight": 76,
+    "FieldOfView": [76, 76],
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
     "Environment": "exvivo"

--- a/sub-rat3/microscopy/sub-rat3_sample-data9_SEM.json
+++ b/sub-rat3/microscopy/sub-rat3_sample-data9_SEM.json
@@ -2,10 +2,7 @@
     "PixelSize": 0.1,
     "FovWidth": 76,
     "FovHeight": 76,
-    "Species": "rat",
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
-    "Channels": 1,
-    "BitDepth": 8,
     "Environment": "exvivo"
 }

--- a/sub-rat3/microscopy/sub-rat3_sample-data9_SEM.json
+++ b/sub-rat3/microscopy/sub-rat3_sample-data9_SEM.json
@@ -1,5 +1,5 @@
 {
-    "PixelSize": 0.1,
+    "PixelSize": [0.1, 0.1],
     "FieldOfView": [76, 76],
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",

--- a/sub-rat4/microscopy/sub-rat4_sample-data12_SEM.json
+++ b/sub-rat4/microscopy/sub-rat4_sample-data12_SEM.json
@@ -2,10 +2,7 @@
     "PixelSize": 0.1,
     "FovWidth": 82,
     "FovHeight": 77,
-    "Species": "rat",
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
-    "Channels": 1,
-    "BitDepth": 8,
     "Environment": "exvivo"
 }

--- a/sub-rat4/microscopy/sub-rat4_sample-data12_SEM.json
+++ b/sub-rat4/microscopy/sub-rat4_sample-data12_SEM.json
@@ -1,7 +1,6 @@
 {
     "PixelSize": 0.1,
-    "FovWidth": 82,
-    "FovHeight": 77,
+    "FieldOfView": [82, 77],
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
     "Environment": "exvivo"

--- a/sub-rat4/microscopy/sub-rat4_sample-data12_SEM.json
+++ b/sub-rat4/microscopy/sub-rat4_sample-data12_SEM.json
@@ -1,5 +1,5 @@
 {
-    "PixelSize": 0.1,
+    "PixelSize": [0.1, 0.1],
     "FieldOfView": [82, 77],
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",

--- a/sub-rat5/microscopy/sub-rat5_sample-data14_SEM.json
+++ b/sub-rat5/microscopy/sub-rat5_sample-data14_SEM.json
@@ -1,5 +1,5 @@
 {
-    "PixelSize": 0.13,
+    "PixelSize": [0.13, 0.13],
     "FieldOfView": [247, 234],
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",

--- a/sub-rat5/microscopy/sub-rat5_sample-data14_SEM.json
+++ b/sub-rat5/microscopy/sub-rat5_sample-data14_SEM.json
@@ -1,7 +1,6 @@
 {
     "PixelSize": 0.13,
-    "FovWidth": 247,
-    "FovHeight": 234,
+    "FieldOfView": [247, 234],
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
     "Environment": "exvivo"

--- a/sub-rat5/microscopy/sub-rat5_sample-data14_SEM.json
+++ b/sub-rat5/microscopy/sub-rat5_sample-data14_SEM.json
@@ -2,10 +2,7 @@
     "PixelSize": 0.13,
     "FovWidth": 247,
     "FovHeight": 234,
-    "Species": "rat",
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
-    "Channels": 1,
-    "BitDepth": 8,
     "Environment": "exvivo"
 }

--- a/sub-rat6/microscopy/sub-rat6_sample-data15_SEM.json
+++ b/sub-rat6/microscopy/sub-rat6_sample-data15_SEM.json
@@ -1,5 +1,5 @@
 {
-    "PixelSize": 0.13,
+    "PixelSize": [0.13, 0.13],
     "FieldOfView": [150, 97],
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",

--- a/sub-rat6/microscopy/sub-rat6_sample-data15_SEM.json
+++ b/sub-rat6/microscopy/sub-rat6_sample-data15_SEM.json
@@ -2,10 +2,7 @@
     "PixelSize": 0.13,
     "FovWidth": 150,
     "FovHeight": 97,
-    "Species": "rat",
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
-    "Channels": 1,
-    "BitDepth": 8,
     "Environment": "exvivo"
 }

--- a/sub-rat6/microscopy/sub-rat6_sample-data15_SEM.json
+++ b/sub-rat6/microscopy/sub-rat6_sample-data15_SEM.json
@@ -1,7 +1,6 @@
 {
     "PixelSize": 0.13,
-    "FovWidth": 150,
-    "FovHeight": 97,
+    "FieldOfView": [150, 97],
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
     "Environment": "exvivo"

--- a/sub-rat7/microscopy/sub-rat7_sample-Maxo03img60_SEM.json
+++ b/sub-rat7/microscopy/sub-rat7_sample-Maxo03img60_SEM.json
@@ -1,5 +1,5 @@
 {
-    "PixelSize": 0.07,
+    "PixelSize": [0.07, 0.07],
     "FieldOfView": [140, 140],
     "Environment": "exvivo"
 }

--- a/sub-rat7/microscopy/sub-rat7_sample-Maxo03img60_SEM.json
+++ b/sub-rat7/microscopy/sub-rat7_sample-Maxo03img60_SEM.json
@@ -2,7 +2,5 @@
     "PixelSize": 0.07,
     "FovWidth": 140,
     "FovHeight": 140,
-    "Channels": 1,
-    "BitDepth": 8,
     "Environment": "exvivo"
 }

--- a/sub-rat7/microscopy/sub-rat7_sample-Maxo03img60_SEM.json
+++ b/sub-rat7/microscopy/sub-rat7_sample-Maxo03img60_SEM.json
@@ -1,6 +1,5 @@
 {
     "PixelSize": 0.07,
-    "FovWidth": 140,
-    "FovHeight": 140,
+    "FieldOfView": [140, 140],
     "Environment": "exvivo"
 }

--- a/sub-rat8/microscopy/sub-rat8_sample-V915_SEM.json
+++ b/sub-rat8/microscopy/sub-rat8_sample-V915_SEM.json
@@ -1,5 +1,5 @@
 {
-    "PixelSize": 0.07,
+    "PixelSize": [0.07, 0.07],
     "FieldOfView": [108, 77],
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",

--- a/sub-rat8/microscopy/sub-rat8_sample-V915_SEM.json
+++ b/sub-rat8/microscopy/sub-rat8_sample-V915_SEM.json
@@ -1,7 +1,6 @@
 {
     "PixelSize": 0.07,
-    "FovWidth": 108,
-    "FovHeight": 77,
+    "FieldOfView": [108, 77],
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
     "Environment": "exvivo"

--- a/sub-rat8/microscopy/sub-rat8_sample-V915_SEM.json
+++ b/sub-rat8/microscopy/sub-rat8_sample-V915_SEM.json
@@ -2,10 +2,7 @@
     "PixelSize": 0.07,
     "FovWidth": 108,
     "FovHeight": 77,
-    "Species": "rat",
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
-    "Channels": 1,
-    "BitDepth": 8,
     "Environment": "exvivo"
 }


### PR DESCRIPTION
This PR aims to update the example dataset to the latest version of the Microscopy BEP031 version 0.0.4 (2021-07-13T15:14:00).
All changes done are documented in issue #3.

After the merge and release of this new version, the dataset will also become the official SEM dataset for AxonDeepSeg, therefore after the release we will have to:
- [ ] Transfer the repo to AxonDeepSeg organization
- [ ] Update the name of repo to “data_axondeepseg_sem”
- [ ] Update link to the release in the BEP

Other changes may have to be done while we are finalizing the BEP but we need to move on now with the BIDSifying of our datasets for the re-training of the models in ivadomed.